### PR TITLE
End of cycle reports

### DIFF
--- a/src/Kaleidoscope/PrefixLayer.cpp
+++ b/src/Kaleidoscope/PrefixLayer.cpp
@@ -37,6 +37,14 @@ EventHandlerResult PrefixLayer::onKeyswitchEvent(Key &mapped_key, byte row, byte
   }
 
   if (keyToggledOn(keyState) && mapped_key.raw <= kaleidoscope::ranges::FIRST) {
+    key_toggled_on_ = true;
+  }
+
+  return EventHandlerResult::OK;
+}
+
+EventHandlerResult PrefixLayer::beforeReportingState() {
+  if (key_toggled_on_) {
     for (uint8_t i = 0;; i++) {
       uint16_t layer = pgm_read_word(&(dict[i].layer));
       if (layer == 0xFFFF) break;
@@ -60,6 +68,7 @@ EventHandlerResult PrefixLayer::onKeyswitchEvent(Key &mapped_key, byte row, byte
       }
     }
   }
+  key_toggled_on_ = false;
 
   return EventHandlerResult::OK;
 }

--- a/src/Kaleidoscope/PrefixLayer.h
+++ b/src/Kaleidoscope/PrefixLayer.h
@@ -45,7 +45,7 @@ class PrefixLayer : public kaleidoscope::Plugin {
   EventHandlerResult beforeReportingState();
 
  private:
-  bool key_toggled_on_{false};
+  Key key_toggled_on_{Key_NoKey};
 };
 };
 };

--- a/src/Kaleidoscope/PrefixLayer.h
+++ b/src/Kaleidoscope/PrefixLayer.h
@@ -42,6 +42,10 @@ class PrefixLayer : public kaleidoscope::Plugin {
    static const dict_t *dict;
 
    EventHandlerResult onKeyswitchEvent(Key &mapped_key, byte row, byte col, uint8_t keyState);
+  EventHandlerResult beforeReportingState();
+
+ private:
+  bool key_toggled_on_{false};
 };
 };
 };


### PR DESCRIPTION
This is a demonstration of how a plugin might be changed to avoid sending mid-cycle reports based on the incomplete HID report.

### The upside

Reports are only sent after the scan cycle is finished, so they're never based on a partial report. This means that rollover from a later-scanned key to an earlier-scanned key won't result in an unintended release and press event on the host.

### The downside

I've tried to make the minimal, simplest change I could, so I decided to neglect doing anything to handle multiple keys toggling on in the same cycle. In this case, if two or more keys toggle on "simultaneously", the last one in the scan order wins, and the earlier one(s) get delayed a cycle before they appear in the output. Even then, they don't ever get their keypress event handled by any plugins that follow PrefixLayer in the plugin order. This is perhaps not of great concern because the probability of this happening is quite low, and the user's intent is arguably unclear.

Perhaps of more concern is that we now have to block the original keypress event, and call `onKeyswitchEvent()` after the prefix reports have been sent. PrefixLayer itself needs to ignore this injected event, so I used the `INJECTED` flag, as is the common practice. However, this injected event is different from the original. First, other plugins also ignore `INJECTED` events, and would therefore ignore this one, which was not the case before this change. Second, the injected event sets the row and column to `UNKNOWN_KEYSWITCH_LOCATION` instead of the real coordinates of the keyswitch that was pressed. We could store that, as well, of course, but that would mean even more bookkeeping for the plugin.