### PR TITLE
Stash mid-cycle reports

### DIFF
--- a/src/Kaleidoscope/PrefixLayer.cpp
+++ b/src/Kaleidoscope/PrefixLayer.cpp
@@ -41,6 +41,7 @@ EventHandlerResult PrefixLayer::onKeyswitchEvent(Key &mapped_key, byte row, byte
       uint16_t layer = pgm_read_word(&(dict[i].layer));
       if (layer == 0xFFFF) break;
       if (Layer.isActive(layer)) {
+        hid::stashKeyboardReport();
         for (uint8_t j = 0;; j++) {
           Key k;
           k.raw = pgm_read_word(&(dict[i].prefix_seq[j].raw));
@@ -57,6 +58,7 @@ EventHandlerResult PrefixLayer::onKeyswitchEvent(Key &mapped_key, byte row, byte
                                WAS_PRESSED | INJECTED);
         }
         hid::sendKeyboardReport();
+        hid::restoreKeyboardReport();
       }
     }
   }


### PR DESCRIPTION
This is a demonstration of how a plugin might be changed to send mid-cycle reports safely by basing them on the previous (complete) report, rather than the current (incomplete) one.

### The upside

The problem of rollover from a later-scanned key to an earlier one is solved; we no longer get spurious key-release and -press events on the host because of the mid-cycle report that we sent. This result should be the same as if we switch to using end-of-cycle reports (see #1).

### The downside

This requires Kaleidoscope to keep track of the stashed report, and requires the plugin to correctly stash and restore the report at the appropriate places.

---
### Compared to end-of-cyle reports (#1)

- This requires the addition of only two lines of code, _vs_ quite a bit of reorganization, the addition of a whole hook function, and state variable(s) to delay the event(s).
- There is no problem with multiple keypress events in the same cycle.
- The events for the pressed key are not flagged `INJECTED`, so other plugins won't be affected by it.
- The event for the pressed key gets its `row` and `col` coordinates without any extra bookkeeping.
- The event for the pressed key occurs in the usual order, during the scan cycle, not after some plugins have already run their `beforeReportingState()` hook.

Some of these issues can be addressed by adding more code and state to #1, but it's quite a bit simpler to do it by stashing the mid-cycle reports.